### PR TITLE
relax validation requirements on subjective data returned by get_wall_time

### DIFF
--- a/esr_subjective_data.md
+++ b/esr_subjective_data.md
@@ -51,7 +51,7 @@ verifies the following:
 
 `get_wall_time` returns the wall-clock time with microsecond accuracy. During validation, nodeos
 verifies the following:
-* The result is non-decreasing across a block.
+* The result is non-decreasing across a transaction.
 * The result is >= (the block time of the current block - 0.5s)
 * The result is <= (the block time of the current block + 0.5s)
 


### PR DESCRIPTION
I am concerned about validation requirements on the subjective data returned by `get_wall_time`; I consider one of the requirements overly restrictive. The proposal currently requires that the wall clock time returned by the intrinsic increases monotonically across all transactions in the block. This assumes that transactions have linear ordering. That is currently true, but we may wish to explore enhancements to the EOSIO protocol in the future that requires transactions to be serializable but no longer requires linearizability (for example enabling concurrent transaction execution). 

So in this PR I propose relaxing the validation rules to ensure the wall clock time monotonically increases only within the _transaction_ (not block), so that we avoid constraining certain optimization/parallelization options for the future. 